### PR TITLE
Add WCA Live (new) URL alongside legacy WCA Live

### DIFF
--- a/src/lib/components/CompetitionCard.svelte
+++ b/src/lib/components/CompetitionCard.svelte
@@ -33,11 +33,20 @@
 		<ul class="my-4 space-y-3 flex flex-col items-center w-full">
 			<li class="w-full max-w-xs">
 				<LinkButton
-					href={EXTERNAL_URLS.wcaLive(competition.id)}
+					href={EXTERNAL_URLS.wcaLiveNew(competition.id)}
 					external
 					className="w-full"
 				>
 					WCA Live
+				</LinkButton>
+			</li>
+			<li class="w-full max-w-xs">
+				<LinkButton
+					href={EXTERNAL_URLS.wcaLive(competition.id)}
+					external
+					className="w-full"
+				>
+					WCA Live (old)
 				</LinkButton>
 			</li>
 			<li class="w-full max-w-xs">

--- a/src/lib/components/CompetitionCard.svelte
+++ b/src/lib/components/CompetitionCard.svelte
@@ -33,7 +33,7 @@
 		<ul class="my-4 space-y-3 flex flex-col items-center w-full">
 			<li class="w-full max-w-xs">
 				<LinkButton
-					href={EXTERNAL_URLS.wcaLiveNew(competition.id)}
+					href={EXTERNAL_URLS.wcaLive(competition.id)}
 					external
 					className="w-full"
 				>
@@ -42,11 +42,11 @@
 			</li>
 			<li class="w-full max-w-xs">
 				<LinkButton
-					href={EXTERNAL_URLS.wcaLive(competition.id)}
+					href={EXTERNAL_URLS.wcaLiveNew(competition.id)}
 					external
 					className="w-full"
 				>
-					WCA Live (old)
+					WCA Live (new)
 				</LinkButton>
 			</li>
 			<li class="w-full max-w-xs">

--- a/src/lib/components/CompetitionCard.svelte
+++ b/src/lib/components/CompetitionCard.svelte
@@ -31,20 +31,18 @@
 			</a>
 		</h2>
 		<ul class="my-4 space-y-3 flex flex-col items-center w-full">
-			<li class="w-full max-w-xs">
+			<li class="w-full max-w-xs flex gap-2">
 				<LinkButton
 					href={EXTERNAL_URLS.wcaLive(competition.id)}
 					external
-					className="w-full"
+					className="flex-1"
 				>
 					WCA Live
 				</LinkButton>
-			</li>
-			<li class="w-full max-w-xs">
 				<LinkButton
 					href={EXTERNAL_URLS.wcaLiveNew(competition.id)}
 					external
-					className="w-full"
+					className="flex-1"
 				>
 					WCA Live (new)
 				</LinkButton>

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -16,6 +16,13 @@ describe('Configuration', () => {
 			);
 		});
 
+		it('should generate correct WCA Live (new) URL', () => {
+			const url = EXTERNAL_URLS.wcaLiveNew('test-comp-2025');
+			expect(url).toBe(
+				'https://www.worldcubeassociation.org/competitions/test-comp-2025/live'
+			);
+		});
+
 		it('should generate correct Competition Groups URL', () => {
 			const url = EXTERNAL_URLS.competitionGroups('test-comp-2025');
 			expect(url).toBe(

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -14,6 +14,13 @@ export const EXTERNAL_URLS = {
 		`https://live.worldcubeassociation.org/link/competitions/${competitionId}`,
 
 	/**
+	 * WCA Live competition URL on the main WCA website. Replaces wcaLive for
+	 * comps that have been migrated; both currently coexist during rollout.
+	 */
+	wcaLiveNew: (competitionId: string) =>
+		`https://www.worldcubeassociation.org/competitions/${competitionId}/live`,
+
+	/**
 	 * Competition Groups URL
 	 */
 	competitionGroups: (competitionId: string) =>


### PR DESCRIPTION
Adds wcaLiveNew helper pointing at worldcubeassociation.org/competitions/{id}/live and exposes both as separate "WCA Live" and "WCA Live (old)" buttons on the competition card while the WCA rollout is in progress.